### PR TITLE
fix grid layout for components

### DIFF
--- a/src/components/AllProducts/AllProducts.jsx
+++ b/src/components/AllProducts/AllProducts.jsx
@@ -27,9 +27,7 @@ const AllProducts = () => {
   return (
     <>
       <Breadcrumbs />
-      <div
-        className={`${styles.allProducts_container} side_padding bottom_margin `}
-      >
+      <div className={`${styles.allProducts_container} bottom_margin `}>
         <h2>All products</h2>
 
         <Filters price={true} discount={true} sort={true} />

--- a/src/components/Categories/CategoriesList.jsx
+++ b/src/components/Categories/CategoriesList.jsx
@@ -4,7 +4,6 @@ import { useSelector, useDispatch } from "react-redux";
 import { useEffect, useState } from "react";
 import { fetchCategories } from "../../redux/slices/categoriesSlice";
 
-
 const CategoriesList = ({ limit }) => {
   const [displayedItems, setDisplayedItems] = useState([]);
   const categories = useSelector((state) => state.categories.categories);
@@ -21,18 +20,16 @@ const CategoriesList = ({ limit }) => {
   }, [categories, limit]);
 
   return (
-     
-      <div className={styles.categories}>
-        {displayedItems.map((category) => (
-          <CategoryCard
-            key={category.id}
-            id={category.id}
-            categoryTitle={category.title}
-            image={category.image}
-          />
-        ))}
-      </div>
-   
+    <div className={`${styles.categories} side_padding`}>
+      {displayedItems.map((category) => (
+        <CategoryCard
+          key={category.id}
+          id={category.id}
+          categoryTitle={category.title}
+          image={category.image}
+        />
+      ))}
+    </div>
   );
 };
 

--- a/src/components/Categories/CategoriesList.module.css
+++ b/src/components/Categories/CategoriesList.module.css
@@ -1,39 +1,23 @@
 .categories {
-  margin-top: 20px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 20px;
-  padding: 0 20px;
 }
 
 @media (min-width: 480px) {
   .categories {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
-    gap: 20px;
-    margin-bottom: 56px;
+    grid-template-columns: 1fr 1fr;
   }
 }
-@media (min-width: 768px) {
-  .categories {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 30px;
-  }
-}
+
 @media (min-width: 1000px) {
   .categories {
-    display: flex;
-    flex-direction: row;
-    gap: 1.25rem;
-    margin: 24px auto 56px;
+    grid-template-columns: repeat(4, 1fr);
   }
 }
-@media (min-width: 1400px) {
+
+@media (min-width: 1440px) {
   .categories {
-    gap: 1.85rem;
-    padding: 0 40px;
+    gap: 32px;
   }
 }

--- a/src/components/DiscountedProducts/DiscountedProducts.jsx
+++ b/src/components/DiscountedProducts/DiscountedProducts.jsx
@@ -22,11 +22,7 @@ const DiscountedProducts = () => {
 
       {status === "loading" && <SkeletonGrid count={12} />}
       {status === "failed" && <div>Error: {error}</div>}
-      <div
-        className={`${styles.discountedProducts} side_padding responsive_cards`}
-      >
-        <ProductsList />
-      </div>
+      <ProductsList />
     </>
   );
 };

--- a/src/components/LikedProducts/LikedProducts.jsx
+++ b/src/components/LikedProducts/LikedProducts.jsx
@@ -34,7 +34,7 @@ const LikedProducts = () => {
         ) : favProducts.length === 0 ? (
           <p>Empty</p>
         ) : (
-          <div className={`${styles.likedProducts_items} responsive_cards`}>
+          <div className={`responsive_cards`}>
             {favProducts.map((product) => (
               <ProductCard
                 key={product.id}

--- a/src/components/ProductsByCategory/ProductsByCategory.jsx
+++ b/src/components/ProductsByCategory/ProductsByCategory.jsx
@@ -45,7 +45,7 @@ function ProductsByCategory() {
       {status === "loading" && <SkeletonGrid count={12} />}
       {status === "failed" && <p>{error}</p>}
       {status === "succeeded" && (
-        <div className={`${style.productsByCategory} responsive_cards`}>
+        <div className={`responsive_cards`}>
           {categoryProducts.length === 0 ? (
             <p>Empty</p>
           ) : (

--- a/src/components/ProductsList/ProductsList.jsx
+++ b/src/components/ProductsList/ProductsList.jsx
@@ -20,7 +20,7 @@ const ProductsList = () => {
     return inPriceRange && discountOk;
   });
   return (
-    <div className={`${styles.productsList} responsive_cards`}>
+    <div className={`side_padding responsive_cards`}>
       {filteredProducts.map((product) => {
         return (
           <ProductCard

--- a/src/components/SaleSection/SaleSection.module.css
+++ b/src/components/SaleSection/SaleSection.module.css
@@ -1,14 +1,23 @@
 .saleSection {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-  gap: clamp(5px, 3vw, 20px);
+  grid-template-columns: 1fr;
+  gap: 20px;
 }
 
-@media (max-width: 480px) {
+@media (min-width: 480px) {
   .saleSection {
-    grid-template-columns: 1fr;
-    grid-template-rows: 4fr;
-    gap: 5px;
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (min-width: 1000px) {
+  .saleSection {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (min-width: 1440px) {
+  .saleSection {
+    gap: 32px;
   }
 }

--- a/src/components/SectionHeader/SectionHeader.module.css
+++ b/src/components/SectionHeader/SectionHeader.module.css
@@ -4,6 +4,7 @@
   justify-content: space-between;
   align-items: center;
   margin-top: 56px;
+  margin-bottom: 24px;
 
   h2 {
     font-size: clamp(2.5rem, 7.3vw, 4rem);
@@ -16,4 +17,18 @@
   flex: 1;
   height: 1px;
   background-color: var(--color-grey-divider);
+}
+
+@media (min-width: 768px) {
+  .sectionHeader {
+    margin-top: 60px;
+    margin-bottom: 32px;
+  }
+}
+
+@media (min-width: 1440px) {
+  .sectionHeader {
+    margin-top: 80px;
+    margin-bottom: 40px;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -10,14 +10,13 @@
   --color-grey-divider: #dddddd;
   --color-grey: #8b8b8b;
   --color-light-grey: #f2f6d3;
-  --color-white-cart:#ffffff;
+  --color-white-cart: #ffffff;
 }
 
-html.dark{
+html.dark {
   --text-black: #ffffff;
   --text-white: #ffffff;
   --text-grey: #8b8b8b;
-
 
   --color-green: #92a134;
   --color-sale: #f26d22;
@@ -25,12 +24,9 @@ html.dark{
   --color-black: #fffff1;
   --color-grey-divider: #dddddd;
   --color-grey: #8b8b8b;
-  --color-light-grey: #383A2C;
-  --color-white-cart: #383A2C;
-
-;
+  --color-light-grey: #383a2c;
+  --color-white-cart: #383a2c;
 }
-
 
 * {
   box-sizing: border-box;
@@ -100,7 +96,7 @@ ol {
 
 .responsive_cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   width: 100%;
   gap: 20px;
 }

--- a/src/pages/Categories/CategoriesPage.module.css
+++ b/src/pages/Categories/CategoriesPage.module.css
@@ -1,17 +1,18 @@
 .categoriesPage {
- width: 100%;
+  width: 100%;
   display: flex;
   flex-direction: column;
-    }
+}
 
 @media (min-width: 1000px) {
   .categoriesPage {
-   display: flex;
+    display: flex;
     flex-direction: row;
     flex-wrap: wrap;
     gap: 20px;
   }
 }
+
 @media (min-width: 1400px) {
   .categoriesPage {
     display: flex;
@@ -19,6 +20,3 @@
     gap: 30px;
   }
 }
-
-
-

--- a/src/pages/Favorites/Favorites.module.css
+++ b/src/pages/Favorites/Favorites.module.css
@@ -1,6 +1,2 @@
 .favorites {
-  width: clamp(320px, 35%, 700px);
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 1rem;
 }


### PR DESCRIPTION
Поправил сетку для Компонентов, использующих grid. Сделал min=240. При такой минимальной ширине получается ближайшее попадание к сетке. Но не точное. И при максимальной ширине - колонок 5. 
Так же поправил стили для секций "Категории" и "Распродажи" на главной. Привел к единому виду. 
У компонентов, у которых есть глобальный класс .responsive_cards удалил второй класс так как он дублировал, а, местами и не давал, применить сетку. 